### PR TITLE
feat: avoid writes from find service when using dynamo

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -143,12 +143,16 @@ func daemonAction(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	defer dsTmp.Close()
-	err = cleanupDTTempData(cctx.Context, dsTmp)
-	if err != nil {
-		return err
+
+	if dsTmp != nil {
+		defer dsTmp.Close()
+		err = cleanupDTTempData(cctx.Context, dsTmp)
+		if err != nil {
+			return err
+		}
+
+		freezeDirs = append(freezeDirs, dsTmpDir)
 	}
-	freezeDirs = append(freezeDirs, dsTmpDir)
 
 	if cfg.Indexer.UnfreezeOnStart {
 		unfrozen, err := registry.Unfreeze(cctx.Context, freezeDirs, cfg.Indexer.FreezeAtPercent, dstore)

--- a/command/datastore.go
+++ b/command/datastore.go
@@ -34,7 +34,11 @@ func createDatastore(ctx context.Context, cfg config.Datastore) (datastore.Batch
 }
 
 func createTmpDatastore(ctx context.Context, cfg config.Datastore) (datastore.Batching, string, error) {
-	return createDS(ctx, cfg.Type, cfg.TmpDir, cfg.TmpRegion, cfg.RemoveTmpAtStart)
+	if cfg.TmpType == "" || cfg.TmpType == "none" {
+		return nil, "", nil
+	}
+
+	return createDS(ctx, cfg.TmpType, cfg.TmpDir, cfg.TmpRegion, cfg.RemoveTmpAtStart)
 }
 
 func createDS(ctx context.Context, dsType, dirOrTable, region string, rmExisting bool) (datastore.Batching, string, error) {

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -16,6 +16,8 @@ type Datastore struct {
 
 	// TmpType is the type of datastore for temporary persisted data.
 	// Currently, only "levelds" and "dynamodb" are supported.
+	// Use "none" to disable the tmp datastore. The tmp datastore is used by the ingest
+	// service, so it should also be disabled if the tmp datastore is disabled.
 	TmpType string
 	// TmpDir is the directory where the datastore for persisted temporary data
 	// is kept. This datastore contains temporary items such as synced

--- a/deploy/.env.production.local.tpl
+++ b/deploy/.env.production.local.tpl
@@ -13,10 +13,10 @@ fi
     "PrivKey": ""
   },
   "Addresses": {
-    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Admin": "none",
     "Finder": "/ip4/0.0.0.0/tcp/3000",
-    "Ingest": "/ip4/0.0.0.0/tcp/3001",
-    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "Ingest": "none",
+    "P2PAddr": "none",
     "NoResourceManager": true
   },
   "Bootstrap": {
@@ -40,9 +40,9 @@ fi
     "Type": "dynamodb",
     "Dir": "${TABLE_PREFIX}-datastore",
     "Region": "$TF_VAR_region",
-    "TmpType": "dynamodb",
-    "TmpDir": "${TABLE_PREFIX}-tmp-datastore",
-    "TmpRegion": "$TF_VAR_region"
+    "TmpType": "none",
+    "TmpDir": "",
+    "TmpRegion": ""
   },
   "Discovery": {
     "FilterIPs": true,
@@ -69,19 +69,7 @@ fi
     "DynamoDBMultihashMapTable": "${TABLE_PREFIX}-multihash-map",
     "FreezeAtPercent": -1
   },
-  "Ingest": {
-    "AdvertisementDepthLimit": 33554432,
-    "EntriesDepthLimit": 65536,
-    "HttpSyncRetryMax": 0,
-    "HttpSyncRetryWaitMax": "30s",
-    "HttpSyncRetryWaitMin": "1s",
-    "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
-    "PubSubTopic": "/indexer/ingest/mainnet",
-    "ResendDirectAnnounce": false,
-    "SyncSegmentDepthLimit": 2000,
-    "SyncTimeout": "2h0m0s"
-  },
+  "Ingest": {},
   "Logging": {
     "Level": "info",
       "Loggers": {

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1,0 +1,26 @@
+package indexer
+
+import idxrcore "github.com/ipni/go-indexer-core"
+
+type Indexer interface {
+	idxrcore.Interface
+	HasIndexedStore() bool
+}
+
+var _ Indexer = (*indexer)(nil)
+
+type indexer struct {
+	idxrcore.Interface
+	indexedStore bool
+}
+
+func New(core idxrcore.Interface, indexedStore bool) *indexer {
+	return &indexer{
+		Interface:    core,
+		indexedStore: indexedStore,
+	}
+}
+
+func (i *indexer) HasIndexedStore() bool {
+	return i.indexedStore
+}

--- a/server/find/extended_providers_test.go
+++ b/server/find/extended_providers_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-test/random"
-	"github.com/ipni/go-indexer-core"
+	idxrcore "github.com/ipni/go-indexer-core"
 	"github.com/ipni/go-libipni/find/client"
 	"github.com/ipni/go-libipni/find/model"
+	"github.com/ipni/storetheindex/indexer"
 	"github.com/ipni/storetheindex/internal/registry"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -16,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	provider1Id, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -54,7 +55,7 @@ func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 	require.NoError(t, err)
 }
 
-func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	provider1Id, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -121,7 +122,7 @@ func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 	require.NoError(t, err)
 }
 
-func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	provider1Id, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -184,7 +185,7 @@ func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 	require.NoError(t, err)
 }
 
-func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	provider1Id, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -219,7 +220,7 @@ func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	ctxId2 := []byte("test-context-id-2")
 	mhs2 := random.Multihashes(10)
 
-	v := indexer.Value{
+	v := idxrcore.Value{
 		ProviderID:    prov1,
 		ContextID:     ctxId2,
 		MetadataBytes: metadata1,
@@ -280,7 +281,7 @@ func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	require.NoError(t, err)
 }
 
-func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	provider1Id, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -335,7 +336,7 @@ func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 	require.NoError(t, err)
 }
 
-func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	providerId, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	providerMetadata := []byte("provider metadata")
@@ -387,7 +388,7 @@ func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.C
 	require.NoError(t, err)
 }
 
-func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
+func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Indexer, reg *registry.Registry) {
 	providerId, _, _ := random.Identity()
 	ctxId1 := []byte("test-context-id-1")
 	providerMetadata := []byte("provider metadata")
@@ -439,11 +440,11 @@ func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context
 	require.NoError(t, err)
 }
 
-func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind indexer.Interface, reg *registry.Registry, contextID []byte, metadata []byte, providerID peer.ID, addrs []multiaddr.Multiaddr, extendedProviders *registry.ExtendedProviders) (peer.ID, []multihash.Multihash) {
+func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind indexer.Indexer, reg *registry.Registry, contextID []byte, metadata []byte, providerID peer.ID, addrs []multiaddr.Multiaddr, extendedProviders *registry.ExtendedProviders) (peer.ID, []multihash.Multihash) {
 	// Generate some multihashes and populate indexer
 	mhs := random.Multihashes(10)
 
-	v := indexer.Value{
+	v := idxrcore.Value{
 		ProviderID:    providerID,
 		ContextID:     contextID,
 		MetadataBytes: metadata,

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -56,6 +56,7 @@ func (m *mockIndexer) Flush() error                                       { retu
 func (m *mockIndexer) Close() error                                       { return nil }
 func (m *mockIndexer) Iter() (indexer.Iterator, error)                    { return nil, nil }
 func (m *mockIndexer) Stats() (*indexer.Stats, error)                     { return nil, indexer.ErrStatsNotSupported }
+func (m *mockIndexer) HasIndexedStore() bool                              { return false }
 
 func TestHandleRegisterProvider(t *testing.T) {
 	discoveryCfg := config.Discovery{


### PR DESCRIPTION
## Context
We want to deploy find (read) and ingest (write) tasks to allow scaling read workloads horizontally by sharing the same DynamoDB table.

Although the find service does mostly reads, it still does writes to the stores under some circumstances:
1. at service startup, it removes entries from the temp datastore: https://github.com/storacha/storetheindex/blob/8a4485e747ff8e1978ad43f2c22469ac6a241d4d/command/daemon.go#L147
2. it is also in charge of cleaning up entries from providers that have been deleted: https://github.com/storacha/storetheindex/blob/8a4485e747ff8e1978ad43f2c22469ac6a241d4d/server/find/server.go#L493
3. as part of some requests coming through the admin interface: for example https://github.com/storacha/storetheindex/blob/8a4485e747ff8e1978ad43f2c22469ac6a241d4d/server/admin/handler.go#L198 or https://github.com/storacha/storetheindex/blob/8a4485e747ff8e1978ad43f2c22469ac6a241d4d/server/admin/handler.go#L605

## Proposed Changes
The changes address the aforementioned issues:
- to avoid 1, the temp datastore can now be disabled by setting `config.Datastore.TmpType` to `"none"`. The temp datastore is only used by the ingest service, so that is disabled too by setting `config.Addresses.P2PAddr` to `"none"` (a future PR will add a new config where the ingest service will be enabled for ingest tasks).
- to prevent 2, cleanup is delegated to the find service because removing all provider entries from the valuestore causes a full scan. However, this is not true for DynamoDB-based valuestores. I added a new `indexer.Indexer` interface that allows users to know whether the underlying valuestore is indexed, which means that removal of providers is possible without scanning the full collection. When the indexer's valuestore is indexed, cleanup is done by the ingest service rather than the find service.
- regarding 3, to avoid potential issues of the admin interface causing writes to the datastore, it is disabled on find tasks. It will only be available in the ingest task, although inaccessible for now. If we deem it necessary, we can add the required config (load balancer handlers and target groups).

## Tests
For now I only confirmed the service starts as expected with the new code and configuration. I'll do more testing once I finalize the deployment configuration and have the service deployed as independent find and ingest tasks.
