### PR TITLE
fix: proper setup of the DynamoDB client

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -610,8 +610,12 @@ func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.I
 
 		vs, err = pebble.New(dir, pebbleOpts)
 	case vstoreDynamoDB:
-		client := dynamodb.NewClient(cfgIndexer.DynamoDBRegion)
-		vs, err = dynamodb.NewStore(client, cfgIndexer.DynamoDBProvidersTable, cfgIndexer.DynamoDBMultihashMapTable)
+		client, err := dynamodb.NewClient(cfgIndexer.DynamoDBRegion)
+		if err != nil {
+			return nil, 0, "", fmt.Errorf("cannot create dynamodb client: %w", err)
+		}
+
+		vs = dynamodb.NewStore(client, cfgIndexer.DynamoDBProvidersTable, cfgIndexer.DynamoDBMultihashMapTable)
 	default:
 		err = fmt.Errorf("unrecognized store type: %s", cfgIndexer.ValueStoreType)
 	}

--- a/deploy/.env.production.local.tpl
+++ b/deploy/.env.production.local.tpl
@@ -65,8 +65,8 @@ fi
     "ShutdownTimeout": "15m",
     "ValueStoreType": "dynamodb",
     "DynamoDBRegion": "$TF_VAR_region",
-    "DynamoDBProvidersTable": "${TABLE_PREFIX}-providers",
-    "DynamoDBMultihashMapTable": "${TABLE_PREFIX}-multihash-map",
+    "DynamoDBProvidersTable": "${TABLE_PREFIX}-valuestore-providers",
+    "DynamoDBMultihashMapTable": "${TABLE_PREFIX}-valuestore-multihash-map",
     "FreezeAtPercent": -1
   },
   "Ingest": {

--- a/store/dynamodb/dynamodb_test.go
+++ b/store/dynamodb/dynamodb_test.go
@@ -103,8 +103,7 @@ func TestDDBStore_Get(t *testing.T) {
 			}
 
 			// Create store with mock client
-			store, err := NewStore(mockClient, "test-providers", "test-multihashes")
-			require.NoError(t, err)
+			store := NewStore(mockClient, "test-providers", "test-multihashes")
 
 			// Test Get
 			values, exists, err := store.Get(mh)
@@ -260,11 +259,10 @@ func TestDDBStore_Put(t *testing.T) {
 			}
 
 			// Create store with mock client
-			store, err := NewStore(mockClient, "test-providers", "test-multihashes")
-			require.NoError(t, err)
+			store := NewStore(mockClient, "test-providers", "test-multihashes")
 
 			// Test Put
-			err = store.Put(tt.value, tt.mhs...)
+			err := store.Put(tt.value, tt.mhs...)
 
 			// Assertions
 			if tt.expectedErr {
@@ -340,11 +338,10 @@ func TestDDBStore_Remove(t *testing.T) {
 			}
 
 			// Create store with mock client
-			store, err := NewStore(mockClient, "test-providers", "test-multihashes")
-			require.NoError(t, err)
+			store := NewStore(mockClient, "test-providers", "test-multihashes")
 
 			// Test Remove
-			err = store.Remove(tt.value, tt.mhs...)
+			err := store.Remove(tt.value, tt.mhs...)
 
 			// Assertions
 			if tt.expectedErr {
@@ -491,11 +488,10 @@ func TestDDBStore_RemoveProvider(t *testing.T) {
 			}
 
 			// Create store with mock client
-			store, err := NewStore(mockClient, "test-providers", "test-multihashes")
-			require.NoError(t, err)
+			store := NewStore(mockClient, "test-providers", "test-multihashes")
 
 			// Test RemoveProvider
-			err = store.RemoveProvider(context.Background(), tt.providerID)
+			err := store.RemoveProvider(context.Background(), tt.providerID)
 
 			// Assertions
 			if tt.expectedErr {
@@ -564,11 +560,10 @@ func TestDDBStore_RemoveProviderContext(t *testing.T) {
 			}
 
 			// Create store with mock client
-			store, err := NewStore(mockClient, "test-providers", "test-multihashes")
-			require.NoError(t, err)
+			store := NewStore(mockClient, "test-providers", "test-multihashes")
 
 			// Test RemoveProviderContext
-			err = store.RemoveProviderContext(tt.providerID, tt.contextID)
+			err := store.RemoveProviderContext(tt.providerID, tt.contextID)
 
 			// Assertions
 			if tt.expectedErr {


### PR DESCRIPTION
## Context
I did a quick test of the /cid endpoint and got some error logs related with the dynamodb client not being able to query the corresponding table due to a misconfiguration.

## Tests
Confirmed that the endpoint is working as expected after the changes were deployed.