### PR TITLE
fix: base64-encode contextID when composing valueKeys

### DIFF
--- a/store/dynamodb/dynamodb_test.go
+++ b/store/dynamodb/dynamodb_test.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -42,7 +43,7 @@ func TestDDBStore_Get(t *testing.T) {
 						Items: []map[string]types.AttributeValue{
 							{
 								fieldValueKey: &types.AttributeValueMemberS{
-									Value: providerID.String() + "/" + string(contextID),
+									Value: providerID.String() + "#" + base64.StdEncoding.EncodeToString(contextID),
 								},
 							},
 						},
@@ -179,7 +180,7 @@ func TestDDBStore_Put(t *testing.T) {
 							return false
 						}
 
-						expectedValueKey := providerID.String() + "/" + string(contextID)
+						expectedValueKey := providerID.String() + "#" + base64.StdEncoding.EncodeToString(contextID)
 						for i, req := range reqs {
 							if req.PutRequest == nil {
 								return false


### PR DESCRIPTION
## Context
The multihash-map table in the valuestore associates a multihash with a "value key". The value key is the sort key and it is a composite key built from the providerID and the contextID. The contextID is binary, and the current implementation just "stringifies" it before appending to the value key. Chances are arbitrary binary input will be stringified into the separator used and cause errors when splitting the key back into the original providerID and contextID pair.

To avoid that (and make debugging by humans easier as a side effect), let's encode the contextID using base64 and change the separator to the `'#'` char, which is not part of the base64 alphabet.

## Proposed Changes
Create a couple helper functions that use base64 standard encoding to encode/decode contextIDs.

## Tests
Unit tests were updated. More testing will be done in staging.
