### PR TITLE
fix: data reference to task fails when the task doesn't exist

### DIFF
--- a/deploy/app/ingest/ecs_task.tf
+++ b/deploy/app/ingest/ecs_task.tf
@@ -2,7 +2,10 @@ data "aws_region" "current" {}
 
 # fetch the task definition for the find service to inherit its config
 data "aws_ecs_task_definition" "find" {
-  task_definition = var.find_task_family
+  # this weird conditional is a workaround to avoid terraform failing when the find task doesn't exist (either it
+  # hasn't been deployed yet or it was deleted). The reference to the revision makes this data block dependent on
+  # the find task existing. See https://github.com/hashicorp/terraform-provider-aws/pull/10247
+  task_definition = var.find_task.revision ? var.find_task.family : var.find_task.family
 }
 
 locals {

--- a/deploy/app/ingest/variables.tf
+++ b/deploy/app/ingest/variables.tf
@@ -8,9 +8,12 @@ variable "environment" {
   type        = string
 }
 
-variable "find_task_family" {
+variable "find_task" {
   description = "The task family for the find task, so that we can fetch its configuration"
-  type        = string
+  type        = object({
+    family = string
+    revision = string
+  })
 }
 
 variable "httpport" {

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -122,7 +122,7 @@ module "ingest" {
   vpc = module.app.vpc
   ecs_cluster = module.app.ecs_infra.ecs_cluster
   ecs_log_group = module.app.ecs_infra.aws_cloudwatch_log_group
-  find_task_family = module.app.deployment.task_definition.family
+  find_task = module.app.deployment.task_definition
   lb_listener = module.app.ecs_infra.lb_listener
   lb_security_group = module.app.ecs_infra.lb_security_group
   httpport = 3001


### PR DESCRIPTION
## Context
I hit an error when trying to delete all resources in my dev env. The ingest task has a data reference to the find task created in the app module. If the find task doesn't exist, the data block is obviously not able to get its information. However, terraform doesn't detect the dependency between the two because the `family` property exists in the terraform config itself, i.e. it doesn't depend on the actual resource existing.

A workaround is to reference a property that can only be obtained when the resource exists to force the dependency between the two blocks and allowing terraform to build the right dependency tree.

See https://github.com/hashicorp/terraform-provider-aws/pull/10247 for more information.

## Proposed Changes
Add a no-op reference to `revision`.

## Tests
After the changes, I was able to remove all resources in my env without issues.