### PR TITLE
feat: registry reloads providers periodically

### DIFF
--- a/config/discovery.go
+++ b/config/discovery.go
@@ -44,6 +44,13 @@ type Discovery struct {
 	PollOverrides []Polling
 	// ProviderReloadInterval is the amount of time to wait between reloading
 	// providers from the datastore. Set to 0 to disable periodic reloading.
+	//
+	// This setting should only be used when find and ingest task run as separate
+	// processes. Provider state is kept updated by the ingester, which serves the
+	// requests from providers. Find tasks only read from the datastore when they
+	// start. This setting allows find tasks to go back to persistent storage to
+	// get an up-to-date image of the state of providers.
+	// It should always be set to 0 (disabled) for ingest tasks
 	ProviderReloadInterval Duration
 	// RemoveOldAssignments, if true, removes persisted assignments of previous
 	// versions. When false, previous versions of persisted assignments are

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -42,6 +42,9 @@ type Discovery struct {
 	DeactivateAfter Duration
 	// PollOverrides configures polling for specific providers.
 	PollOverrides []Polling
+	// ProviderReloadInterval is the amount of time to wait between reloading
+	// providers from the datastore. Set to 0 to disable periodic reloading.
+	ProviderReloadInterval Duration
 	// RemoveOldAssignments, if true, removes persisted assignments of previous
 	// versions. When false, previous versions of persisted assignments are
 	// migrated. Only applies if UseAssigner is true.

--- a/deploy/.env.ingest.production.local.tpl
+++ b/deploy/.env.ingest.production.local.tpl
@@ -53,6 +53,7 @@ PREFIX="${TF_WORKSPACE}-${TF_VAR_app}"
     "PollRetryAfter": "5h0m0s",
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
+    "ProviderReloadInterval": "0",
     "UseAssigner": false
   },
   "Indexer": {

--- a/deploy/.env.production.local.tpl
+++ b/deploy/.env.production.local.tpl
@@ -53,6 +53,7 @@ PREFIX="${TF_WORKSPACE}-${TF_VAR_app}"
     "PollRetryAfter": "5h0m0s",
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
+    "ProviderReloadInterval": "10m0s",
     "UseAssigner": false
   },
   "Indexer": {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1121,6 +1121,7 @@ func (r *Registry) periodicProviderReload(interval time.Duration) {
 			providers, err := loadPersistedProviders(context.Background(), r.dstore, r.filterIPs)
 			if err != nil {
 				log.Errorw("cannot reload provider data from datastore", "err", err)
+				return
 			}
 
 			r.provMutex.Lock()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -353,6 +353,10 @@ func New(ctx context.Context, cfg config.Discovery, dstore datastore.Datastore, 
 
 	go r.runTmpBlockCheck()
 
+	if cfg.ProviderReloadInterval != 0 {
+		go r.periodicProviderReload(time.Duration(cfg.ProviderReloadInterval))
+	}
+
 	return r, nil
 }
 
@@ -1104,6 +1108,27 @@ func (r *Registry) SetMaxPoll(maxPoll int) {
 
 func (r *Registry) CheckSequence(peerID peer.ID, seq uint64) error {
 	return r.sequences.check(peerID, seq)
+}
+
+// periodicProviderReload reloads the registry's providers from the datastore.
+func (r *Registry) periodicProviderReload(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-r.closing:
+			return
+		case <-ticker.C:
+			r.provMutex.Lock()
+
+			var err error
+			r.providers, err = loadPersistedProviders(context.Background(), r.dstore, r.filterIPs)
+			if err != nil {
+				log.Errorw("cannot reload provider data from datastore", "err", err)
+			}
+
+			r.provMutex.Unlock()
+		}
+	}
 }
 
 // Freeze puts the indexer into forzen mode.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1118,14 +1118,13 @@ func (r *Registry) periodicProviderReload(interval time.Duration) {
 		case <-r.closing:
 			return
 		case <-ticker.C:
-			r.provMutex.Lock()
-
-			var err error
-			r.providers, err = loadPersistedProviders(context.Background(), r.dstore, r.filterIPs)
+			providers, err := loadPersistedProviders(context.Background(), r.dstore, r.filterIPs)
 			if err != nil {
 				log.Errorw("cannot reload provider data from datastore", "err", err)
 			}
 
+			r.provMutex.Lock()
+			r.providers = providers
 			r.provMutex.Unlock()
 		}
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"slices"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	"github.com/ipfs/go-test/random"
 	"github.com/ipni/go-libipni/find/model"
@@ -969,7 +969,7 @@ func TestIgnoreBadAds(t *testing.T) {
 
 func TestProviderReload(t *testing.T) {
 	ctx := context.Background()
-	ds := datastore.NewMapDatastore()
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	r, err := New(ctx, config.Discovery{ProviderReloadInterval: config.Duration(1 * time.Second)}, ds)
 	require.NoError(t, err)
 	t.Cleanup(func() { r.Close() })
@@ -990,7 +990,7 @@ func TestProviderReload(t *testing.T) {
 	value, err := json.Marshal(pInfo)
 	require.NoError(t, err)
 
-	err = ds.Put(ctx, pInfo.dsKey(), slices.Clone(value))
+	err = ds.Put(ctx, pInfo.dsKey(), value)
 	require.NoError(t, err)
 
 	err = ds.Sync(ctx, pInfo.dsKey())

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"testing"
 	"time"
 
@@ -989,7 +990,7 @@ func TestProviderReload(t *testing.T) {
 	value, err := json.Marshal(pInfo)
 	require.NoError(t, err)
 
-	err = ds.Put(ctx, pInfo.dsKey(), value)
+	err = ds.Put(ctx, pInfo.dsKey(), slices.Clone(value))
 	require.NoError(t, err)
 
 	err = ds.Sync(ctx, pInfo.dsKey())


### PR DESCRIPTION
## Context

Solves #12 

In Storacha's flavour of the IPNI service, ingest and find tasks are split so that only the ingest task ever writes to the providers datastore, while find tasks can concurrently read from it. The registry, which is used both by the ingest task and find tasks, is the component that keeps provider info updated in the providers datastore.

The registry is designed as an in-memory source of truth with a persistence layer. Data from the persistent store is only read once at creation time. This means that find tasks will only have provider information about providers that were already there when the task started. This wouldn't be that much of an issue if it weren't for the fact that provider information is required to fulfil cid/multihash queries. If the corresponding provider info is not there, find will return no results.

This PR adds a basic implementation of a periodic reload of provider info from persistent storage to the registry, allowing it to keep itself up-to-date. This behaviour is only required for find tasks because they don't process advertisements.

The implemented mechanism replaces the existing provider info in-memory map with a new map rebuilt from the datastore. The whole datastore is loaded at once, rather than just the updates. As the number of providers grows, a moment might come where this approach is not convenient anymore.

I briefly explored alternatives to implement a push-based mechanism, instead of the polling-based one added in this PR. However, I think this is something that can be tackled when there is a real problem to solve.

## Proposed Changes

Start an asynchronous task when the registry is created that reloads provider information from the datastore at configurable intervals. Use the `r.closing` channel to know when to exit the asynchronous task.

Add configuration so that only find tasks use a registry configured to reload provider info periodically. Reload interval is configured to 10 min, happy to hear suggestions about what this interval should be. Until the reload is done, queries to multihashes provided by a provider not yet in the registry will return no results.

## Tests

Added a unit test.