### PR TITLE
fix: find tasks shouldn't poll providers

### DIFF
--- a/deploy/.env.production.local.tpl
+++ b/deploy/.env.production.local.tpl
@@ -49,10 +49,7 @@ PREFIX="${TF_WORKSPACE}-${TF_VAR_app}"
       "Publish": true,
       "PublishExcept": null
     },
-    "PollInterval": "24h0m0s",
-    "PollRetryAfter": "5h0m0s",
-    "PollStopAfter": "168h0m0s",
-    "PollOverrides": null,
+    "PollInterval": "0",
     "UseAssigner": false
   },
   "Indexer": {


### PR DESCRIPTION
## Context
The registry component, used by both find and ingest tasks to store provider information, has the ability to poll providers periodically to confirm they are still alive, removing them if they cannot be contacted in a given amount of time.

In Storacha's deployment, find tasks are meant to read from the registry, while the ingest task will update it as it receives announcements and ads. There is no point in find tasks polling providers, as they are not in charge of keeping the registry up to date.

## Proposed Changes
Disable provider polling in the registry configuration for find tasks.

## Tests
Unit tests.