### PR TITLE
fix: use latest version of codecov-action

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   go-test:
-    uses: ipdxco/unified-github-workflows/.github/workflows/go-test.yml@v1.0
+    uses: ipdxco/unified-github-workflows/.github/workflows/go-test.yml@main
     with:
       go-versions: '["this"]'


### PR DESCRIPTION
Uploading coverage files to codecov started failing on windows runners without changes 🤷🏻 
