### PR TITLE
fix: wait for the deployment of the ingest task too

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -155,3 +155,4 @@ console: app/.terraform .tfworkspace eval_image_tag eval_env_file eval_ingest_en
 .PHONY: wait-deploy
 wait-deploy:
 	aws deploy wait deployment-successful --region $(TF_VAR_region) --deployment-id $(shell aws deploy list-deployments --region $(TF_VAR_region) --deployment-group-name $(TF_WORKSPACE)-$(TF_VAR_app)-code-deploy-deployment-group --application-name $(TF_WORKSPACE)-$(TF_VAR_app)-code-deploy-app --query "deployments[0]" --output text)
+	aws deploy wait deployment-successful --region $(TF_VAR_region) --deployment-id $(shell aws deploy list-deployments --region $(TF_VAR_region) --deployment-group-name $(TF_WORKSPACE)-$(TF_VAR_app)-ingest-code-deploy-deployment-group --application-name $(TF_WORKSPACE)-$(TF_VAR_app)-ingest-code-deploy-app --query "deployments[0]" --output text)


### PR DESCRIPTION
## Context
The last step in our terraform deployment workflow is waiting for the CodeDeploy deployment to complete successfully. But we are currently only waiting for the deployment of the find task, and not for the one for the ingest task. I have confirmed that some deployments failed and we didn't notice.

## Proposed Changes
Add an equivalent command to the Makefile so that CI waits for the deployment of the ingest task too.

## Tests
Will test in CI.