### PR TITLE
fix: staging container images fetched from the registry in the prod region

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -10,15 +10,19 @@ else
 endif
 
 ECR_URI=$(TF_VAR_allowed_account_id).dkr.ecr.us-west-2.amazonaws.com
+REPLICATED_ECR_URI=$(TF_VAR_allowed_account_id).dkr.ecr.$(TF_VAR_region).amazonaws.com
 IMAGE_TAG_BASE=$(ECR_URI)/$(TF_VAR_app)-ecr:$(TF_WORKSPACE)
+REPLICATED_IMAGE_TAG_BASE=$(REPLICATED_ECR_URI)/$(TF_VAR_app)-ecr:$(TF_WORKSPACE)
 
 # This is a hack to eval the image tag only when it's a dependency, cause we don't want to set it until docker builds
 get_image_tag = IMAGE_TAG = $$(IMAGE_TAG_BASE)-$$(shell docker inspect --format $$(format-filter) $$(IMAGE_TAG_BASE)-latest | sed -e 's/sha256://g')
+get_replicated_image_tag = REPLICATED_IMAGE_TAG = $$(REPLICATED_IMAGE_TAG_BASE)-$$(shell docker inspect --format $$(format-filter) $$(IMAGE_TAG_BASE)-latest | sed -e 's/sha256://g')
 
 .PHONY: eval_image_tag
 
 eval_image_tag:
 	$(eval $(get_image_tag))
+	$(eval $(get_replicated_image_tag))
 
 # GET the absolute location for .env.production.local, again, only after it exists
 
@@ -60,7 +64,7 @@ docker-push: docker-tag eval_image_tag
 .PHONY: clean-terraform
 
 clean-terraform: eval_image_tag
-	tofu -chdir=app destroy -var="image_tag=$(IMAGE_TAG)" 
+	tofu -chdir=app destroy -var="image_tag=$(REPLICATED_IMAGE_TAG)"
 
 .PHONY: clean-shared
 
@@ -120,7 +124,7 @@ plan-shared: shared/.terraform
 .PHONY: plan-app
 
 plan-app: app/.terraform .tfworkspace eval_image_tag eval_env_file eval_ingest_env_file
-	tofu -chdir=app plan -var="image_tag=$(IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]'
+	tofu -chdir=app plan -var="image_tag=$(REPLICATED_IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]'
 
 .PHONY: plan
 
@@ -139,7 +143,7 @@ apply-shared: shared/.terraform
 .PHONY: apply-app
 
 apply-app: app/.terraform .tfworkspace docker-push eval_image_tag eval_env_file eval_ingest_env_file
-	tofu -chdir=app apply -var="image_tag=$(IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]' $(APPLY_ARGS)
+	tofu -chdir=app apply -var="image_tag=$(REPLICATED_IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]' $(APPLY_ARGS)
 
 .PHONY: apply
 apply: apply-shared apply-app
@@ -150,7 +154,7 @@ console-shared: shared/.terraform
 
 .PHONY: console
 console: app/.terraform .tfworkspace eval_image_tag eval_env_file eval_ingest_env_file
-	tofu -chdir=app console -var="image_tag=$(IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]'
+	tofu -chdir=app console -var="image_tag=$(REPLICATED_IMAGE_TAG)" -var='env_files=["$(ENV_FILE)"]' -var='ingest_env_files=["$(INGEST_ENV_FILE)"]'
 
 .PHONY: wait-deploy
 wait-deploy:

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -41,7 +41,7 @@ provider "aws" {
 }
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.2.43"
+  source = "github.com/storacha/storoku//app?ref=v0.2.44"
   private_key = var.private_key
   private_key_env_var = "STORETHEINDEX_PRIV_KEY"
   httpport = 3000

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -33,10 +33,10 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.2.43"
+  source = "github.com/storacha/storoku//shared?ref=v0.2.44"
   create_db = false
   caches = []
-  networks = ["warm"]
+  networks = ["warm",]
   app = var.app
   zone_id = var.cloudflare_zone_id
   domain_base = var.domain_base


### PR DESCRIPTION
## Context
I introduced an issue in storoku that is fixed in the latest version. Tasks being deployed in the staging region are using the registry in the production region instead.

## Proposed Changes
Upgrade to the latest storoku version that contains the fix for the issue.

## Tests
Will keep an eye to deployment plans to confirm images are fetched from where they should.