### PR TITLE
feat: enable S3 retries

### DIFF
--- a/filestore/config.go
+++ b/filestore/config.go
@@ -3,6 +3,8 @@ package filestore
 import (
 	"errors"
 	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // Config configures a particular file store implementation.
@@ -44,6 +46,7 @@ func MakeFilestore(cfg Config) (Interface, error) {
 			WithEndpoint(cfg.S3.Endpoint),
 			WithRegion(cfg.S3.Region),
 			WithKeys(cfg.S3.AccessKey, cfg.S3.SecretKey),
+			WithRetryMode(aws.RetryModeStandard),
 		)
 	case "":
 		return nil, errors.New("storage type not defined")

--- a/filestore/option.go
+++ b/filestore/option.go
@@ -2,6 +2,8 @@ package filestore
 
 import (
 	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type s3Config struct {
@@ -9,6 +11,7 @@ type s3Config struct {
 	region    string
 	accessKey string
 	secretKey string
+	retryMode aws.RetryMode
 }
 
 type S3Option func(*s3Config) error
@@ -41,6 +44,13 @@ func WithKeys(accessKey, secretKey string) S3Option {
 	return func(c *s3Config) error {
 		c.accessKey = accessKey
 		c.secretKey = secretKey
+		return nil
+	}
+}
+
+func WithRetryMode(mode aws.RetryMode) S3Option {
+	return func(c *s3Config) error {
+		c.retryMode = mode
 		return nil
 	}
 }

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -58,6 +58,10 @@ func NewS3(bucketName string, options ...S3Option) (*S3, error) {
 		cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(staticCreds))
 	}
 
+	if opts.retryMode != "" {
+		cfgOpts = append(cfgOpts, awsconfig.WithRetryMode(opts.retryMode))
+	}
+
 	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(), cfgOpts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Also enable by default.

Hopefully fixes:

```
could not load link \"baguqeeraidgfgewjrh5ybvjd6yjkoy3zvkghdx6ewcjokuoimded5yxk6hlq\": failed to fetch block for cid baguqeeraidgfgewjrh5ybvjd6yjkoy3zvkghdx6ewcjokuoimded5yxk6hlq:
  RequestError: send request failed
    caused by: Put \"https://prod-ipni-tmp-datastore.s3.us-west-2.amazonaws.com/baguqeeraidgfgewjrh5ybvjd6yjkoy3zvkghdx6ewcjokuoimded5yxk6hlq\":
      read tcp 10.0.12.89:58556->52.92.169.18:443:
        read: connection reset by peer
```